### PR TITLE
Add support for keys that include spaces.

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -40,6 +40,9 @@ function AmazonS3URI (uri) {
       // Remove the leading '/'.
       this.key = this.uri.path.substring(1)
     }
+    if (this.key !== null) {
+      this.key = decodeURIComponent(this.key)
+    }
     return
   }
 

--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -96,6 +96,10 @@ function AmazonS3URI (uri) {
   } else {
     this.region = DEFAULT_REGION
   }
+
+  if (this.key !== null) {
+    this.key = decodeURIComponent(this.key)
+  }
 }
 
 AmazonS3URI.prototype.DEFAULT_REGION = DEFAULT_REGION

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "test": "nyc tape 'test/**/*.test.js'",
     "posttest": "nyc report --reporter=lcov"
   },
-  "keywords": ["aws", "s3", "uri", "parser"],
+  "keywords": [
+    "aws",
+    "s3",
+    "uri",
+    "parser"
+  ],
   "author": "Frantz Gauthier <frantz@myentropy.org>",
   "license": "MIT",
   "devDependencies": {

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -49,6 +49,12 @@ const testCases = {
     bucket: 'bucket',
     key: 'key'
   },
+  's3://bucket/key with space': {
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key with space'
+  },
   'https://s3.amazonaws.com/': {
     isPathStyle: true,
     region: 'us-east-1',
@@ -72,6 +78,12 @@ const testCases = {
     region: 'us-east-1',
     bucket: 'bucket',
     key: 'key'
+  },
+  'https://s3.amazonaws.com/bucket/key with space': {
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key with space'
   },
   'https://s3-eu-west-1.amazonaws.com/bucket2/key2': {
     isPathStyle: true,
@@ -97,6 +109,12 @@ const testCases = {
     bucket: 'bucket',
     key: 'key'
   },
+  'https://bucket.s3.amazonaws.com/key with space': {
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key with space'
+  },
   'http://bucket.s3-aws-region.amazonaws.com': {
     isPathStyle: false,
     region: 'aws-region',
@@ -108,6 +126,12 @@ const testCases = {
     region: 'aws-region',
     bucket: 'bucket',
     key: 'key'
+  },
+  'http://bucket.s3-aws-region.amazonaws.com/key with space': {
+    isPathStyle: false,
+    region: 'aws-region',
+    bucket: 'bucket',
+    key: 'key with space'
   }
 }
 

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -79,6 +79,12 @@ const testCases = {
     bucket: 'bucket2',
     key: 'key2'
   },
+  'https://s3-eu-west-1.amazonaws.com/bucket2/key with space': {
+    isPathStyle: true,
+    region: 'eu-west-1',
+    bucket: 'bucket2',
+    key: 'key with space'
+  },
   'https://bucket.s3.amazonaws.com': {
     isPathStyle: false,
     region: 'us-east-1',


### PR DESCRIPTION
Currently, when a bucket key includes a space, this library will return a URL-encoded version, i.e. `key%20with%20space`.

This PR fixes that issue by decoding the URL via `decodeURIComponent`.

This mimics the same behaviour of the source library, e.g.:

https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java#L149