### PR TITLE
Fix prefix operator error on react native

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -18,7 +18,7 @@ const DEFAULT_REGION = 'us-east-1'
  * @throws {TypeError|Error}
  */
 function AmazonS3URI (uri) {
-  if (!new.target) {
+  if (new.target === undefined) {
     return new AmazonS3URI(uri)
   }
   this.uri = url.parse(uri)


### PR DESCRIPTION
Calling `!new.target` causes errors on react native.