### PR TITLE
fix: use for...of to correctly iterate parseQueryString test values

### DIFF
--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -170,7 +170,7 @@ const testCases = {
 Object.keys(testCases).forEach((uri) => {
   test(uri, (t) => {
     // test both values for parseQueryString
-    for (const parseQueryString in [false, true]) {
+    for (const parseQueryString of [false, true]) {
       const uriObj = AmazonS3URI(uri, parseQueryString)
       const tc = testCases[uri](parseQueryString)
       assert.match(uriObj, tc)


### PR DESCRIPTION
## Summary

- `for...in` on an array yields indices (`'0'`, `'1'`), not values — both are truthy strings, so `parseQueryString=false` was never actually exercised in the loop
- Changed to `for...of` so the loop iterates over the actual values `false` and `true` as intended
- The `false` path was only accidentally covered by the third call outside the loop (`AmazonS3URI(uri)` with no `parseQueryString`)

## Test plan

- [ ] `npm test` passes with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)