### PR TITLE
chore: modernise CI — Node 20-24, updated actions, fix Codecov v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,21 +9,22 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - run: npm install
     - run: npm run generate-types --if-present
     - run: npm test
       env:
         CI: true
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/amazon-s3-uri.js",
   "types": "index.d.ts",
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "index.d.ts"


### PR DESCRIPTION
## Summary

- **Fixes CI**: `codecov/codecov-action@v1` uses a legacy bash uploader that no longer accepts tokenless uploads for public repos — updated to v4 which handles public repos natively
- **Node matrix**: 8.x / 10.x / 12.x (all EOL) → 20.x / 22.x / 24.x (current LTS)
- **Action versions**: `actions/checkout` v2→v4, `actions/setup-node` v1→v4 (with `cache: npm`)
- **`engines`**: updated from `>=8.10.0` to `>=20.0.0` to honestly reflect the tested and supported range

## Test plan

- [ ] All three `build (20.x / 22.x / 24.x)` jobs pass
- [ ] Codecov upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)