### PR TITLE
fix: correct bucket parsing for S3 VPC Interface Endpoint (VPCE) URLs

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -88,7 +88,10 @@ function AmazonS3URI (uri, parseQueryString) {
   }
 
   const prefix = matches[1]
-  if (!prefix) {
+  // A VPCE path-style endpoint has the vpce-id as the host prefix with no bucket, e.g.
+  // vpce-<id>-<suffix>.s3.<region>.vpce.amazonaws.com/<bucket>/<key>
+  const isVpcePathStyle = prefix !== undefined && /^vpce-[a-z0-9-]+\.$/.test(prefix)
+  if (!prefix || isVpcePathStyle) {
     // No bucket name in the host; parse it from the path.
     this.isPathStyle = true
 
@@ -116,7 +119,10 @@ function AmazonS3URI (uri, parseQueryString) {
     this.isPathStyle = false
 
     // Remove the trailing '.' from the prefix to get the bucket.
-    this.bucket = prefix.substring(0, prefix.length - 1)
+    // For VPCE virtual-hosted URLs (bucket.vpce-<id>-<suffix>.s3…) strip the vpce suffix.
+    const rawPrefix = prefix.substring(0, prefix.length - 1)
+    const vpceIdx = rawPrefix.indexOf('.vpce-')
+    this.bucket = vpceIdx !== -1 ? rawPrefix.substring(0, vpceIdx) : rawPrefix
 
     if (!this.uri.pathname || this.uri.pathname === '/') {
       this.key = null

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -164,6 +164,43 @@ const testCases = {
     bucket: 'bucket',
     key: 'key with space',
     uri: { query: p ? {} : null }
+  }),
+  // VPCE (VPC Interface Endpoint / PrivateLink) — virtual-hosted style: bucket in host
+  'https://bucket.vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com': (p) => ({
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: null,
+    uri: { query: p ? {} : null }
+  }),
+  'https://bucket.vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/key': (p) => ({
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    uri: { query: p ? {} : null }
+  }),
+  // VPCE — path style: bucket in path
+  'https://vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: null,
+    key: null,
+    uri: { query: p ? {} : null }
+  }),
+  'https://vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/bucket': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: null,
+    uri: { query: p ? {} : null }
+  }),
+  'https://vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/bucket/key': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    uri: { query: p ? {} : null }
   })
 }
 


### PR DESCRIPTION
## Problem

S3 PrivateLink (VPC Interface Endpoint) URLs were parsed incorrectly.

**Virtual-hosted style** — bucket included the VPCE suffix:
```
https://my-bucket.vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/key
# before: bucket = "my-bucket.vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4"  ❌
# after:  bucket = "my-bucket"                                    ✅
```

**Path-style** — VPCE endpoint ID was returned as the bucket name:
```
https://vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4.s3.us-east-1.vpce.amazonaws.com/my-bucket/key
# before: bucket = "vpce-0a1b2c3d4e5f6a7b8-a1b2c3d4"  ❌
# after:  bucket = "my-bucket"                          ✅
```

## Fix

- Path-style VPCE: detect prefix matching `/^vpce-[a-z0-9-]+\.$/` and route through the existing path-style parser
- Virtual-hosted VPCE: strip the `.vpce-<id>-<suffix>` portion from the host prefix before assigning `bucket`

## Tests

5 new test cases covering both URL shapes (with/without key, with/without trailing slash).
Coverage remains at 100%.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)