### PR TITLE
feat: add versionId property parsed from query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A URI wrapper that can parse out information about an S3 URI
 Shamelessly adapted from <https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java>,
 with notable exceptions:
 
-- it doesn't parse `version`
 - There is no preprocessing on given `url` string,
   you have to encode and replace special characters yourself if needed
 - For a valid S3 uri, `region` is never `null` but will default to `us-east-1`

--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -6,7 +6,6 @@ const url = require('url')
 const ENDPOINT_PATTERN = /^(.+\.)?s3[.-]([a-z0-9-]+)\./
 const DEFAULT_REGION = 'us-east-1'
 
-// TODO: support versionId
 // TODO: encode uri before testing
 // TODO: support dualstack http://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html
 
@@ -56,6 +55,11 @@ function AmazonS3URI (uri, parseQueryString) {
    * @type { boolean }
    * */
   this.isPathStyle = false
+  /**
+   * the version ID parsed from the versionId query parameter (or null if not specified)
+   * @type {string | null}
+   */
+  this.versionId = this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null
 
   if (this.uri.protocol === 's3:') {
     this.bucket = this.uri.host

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -128,6 +128,7 @@ const testCases = {
     region: 'us-east-1',
     bucket: 'bucket',
     key: 'key',
+    versionId: null,
     uri: { query: p ? {} : null }
   }),
   'https://bucket.s3.amazonaws.com/key with space': (p) => ({
@@ -201,6 +202,31 @@ const testCases = {
     bucket: 'bucket',
     key: 'key',
     uri: { query: p ? {} : null }
+  }),
+  // versionId support
+  'https://bucket.s3-eu-west-1.amazonaws.com/key?versionId=abc123': (p) => ({
+    isPathStyle: false,
+    region: 'eu-west-1',
+    bucket: 'bucket',
+    key: 'key',
+    versionId: 'abc123',
+    uri: { query: p ? { versionId: 'abc123' } : 'versionId=abc123' }
+  }),
+  'https://s3.amazonaws.com/bucket/key?versionId=v2&foo=bar': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    versionId: 'v2',
+    uri: { query: p ? { versionId: 'v2', foo: 'bar' } : 'versionId=v2&foo=bar' }
+  }),
+  's3://bucket/key?versionId=xyz': (p) => ({
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    versionId: 'xyz',
+    uri: { query: p ? { versionId: 'xyz' } : 'versionId=xyz' }
   })
 }
 


### PR DESCRIPTION
## Summary

- Adds `versionId: string | null` property to `AmazonS3URI`, parsed from the `versionId` query parameter
- Implements the long-standing `// TODO: support versionId` (consistent with the Java SDK reference implementation)
- Guards against constructing `URLSearchParams` when there is no query string (common case)

## Test plan

- [ ] `npm test` — lint + 29 test cases (3 new: virtual-hosted, path-style, and `s3://` with versionId; 1 existing updated to assert `versionId: null`) + 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)