### PR TITLE
feat: add dualstack endpoint support and isDualStack property

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,83 @@
 [![Actions Status](https://github.com/frantz/amazon-s3-uri/workflows/test/badge.svg)](https://github.com/frantz/amazon-s3-uri/actions)
 [![codecov](https://codecov.io/gh/frantz/amazon-s3-uri/branch/master/graph/badge.svg)](https://codecov.io/gh/frantz/amazon-s3-uri)
 
-A URI wrapper that can parse out information about an S3 URI
+A URI wrapper that can parse out information about an S3 URI.
 
-Shamelessly adapted from <https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java>,
-with notable exceptions:
+Adapted from the [AWS Java SDK `AmazonS3URI`](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java), with the following differences:
 
-- There is no preprocessing on given `url` string,
-  you have to encode and replace special characters yourself if needed
-- For a valid S3 uri, `region` is never `null` but will default to `us-east-1`
+- There is no preprocessing on the given URI string — encode special characters yourself if needed
+- `region` is never `null` for a valid S3 URI; it defaults to `us-east-1`
 
-## example
+## Install
+
+```sh
+npm install amazon-s3-uri
+```
+
+## Usage
 
 ```js
 const AmazonS3URI = require("amazon-s3-uri");
 
-try {
-  const uri = "https://bucket.s3-aws-region.amazonaws.com/key";
-  const { region, bucket, key } = AmazonS3URI(uri);
-} catch (err) {
-  // should not happen because `uri` is valid in that example
-  console.warn(`${uri} is not a valid S3 uri`);
-}
+const { region, bucket, key, isPathStyle, isDualStack, versionId } =
+  AmazonS3URI("https://bucket.s3.dualstack.us-east-1.amazonaws.com/key");
+// region      → 'us-east-1'
+// bucket      → 'bucket'
+// key         → 'key'
+// isPathStyle → false
+// isDualStack → true
+// versionId   → null
 ```
 
-## license
+Works both as a constructor and as a plain function call:
+
+```js
+const a = new AmazonS3URI("s3://bucket/key"); // constructor
+const b = AmazonS3URI("s3://bucket/key");     // functional — returns a new instance
+```
+
+Throws `TypeError` for non-string input and `Error` for URIs that cannot be parsed as S3 endpoints.
+
+## Parsed properties
+
+| Property      | Type             | Description |
+|---------------|------------------|-------------|
+| `bucket`      | `string \| null` | Bucket name, or `null` if not present |
+| `key`         | `string \| null` | Object key, or `null` if not present |
+| `region`      | `string`         | AWS region; defaults to `us-east-1` |
+| `isPathStyle` | `boolean`        | `true` when the bucket is in the path rather than the hostname |
+| `isDualStack` | `boolean`        | `true` when the URI uses an S3 dualstack endpoint |
+| `versionId`   | `string \| null` | Value of the `versionId` query parameter, or `null` |
+| `uri`         | `Url`            | Raw `url.parse()` result |
+
+## Supported URI formats
+
+```
+s3://bucket/key
+https://s3.amazonaws.com/bucket/key                           (path-style, global)
+https://s3-eu-west-1.amazonaws.com/bucket/key                 (path-style, regional)
+https://s3.us-east-1.amazonaws.com/bucket/key                 (path-style, regional)
+https://s3.dualstack.us-east-1.amazonaws.com/bucket/key       (path-style, dualstack)
+https://bucket.s3.amazonaws.com/key                           (virtual-hosted, global)
+https://bucket.s3-eu-west-1.amazonaws.com/key                 (virtual-hosted, regional)
+https://bucket.s3.dualstack.us-east-1.amazonaws.com/key       (virtual-hosted, dualstack)
+https://bucket.vpce-xxx.s3.us-east-1.vpce.amazonaws.com/key  (VPCE virtual-hosted)
+https://vpce-xxx.s3.us-east-1.vpce.amazonaws.com/bucket/key  (VPCE path-style)
+```
+
+## `parseQueryString` option
+
+Pass `true` as the second argument to expose `uri.query` as a parsed object instead of a raw string:
+
+```js
+const { uri, versionId } = AmazonS3URI(
+  "https://bucket.s3.amazonaws.com/key?versionId=abc123",
+  true
+);
+// uri.query → { versionId: 'abc123' }
+// versionId → 'abc123'
+```
+
+## License
 
 MIT

--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -3,11 +3,10 @@
 
 const url = require('url')
 
-const ENDPOINT_PATTERN = /^(.+\.)?s3[.-]([a-z0-9-]+)\./
+const ENDPOINT_PATTERN = /^(.+\.)?s3[.-](?:dualstack\.)?([a-z0-9-]+)\./
 const DEFAULT_REGION = 'us-east-1'
 
 // TODO: encode uri before testing
-// TODO: support dualstack http://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html
 
 /**
  * A URI wrapper that can parse out information about an S3 URI
@@ -56,6 +55,11 @@ function AmazonS3URI (uri, parseQueryString) {
    * */
   this.isPathStyle = false
   /**
+   * true if the URI uses an S3 dualstack endpoint
+   * @type {boolean}
+   */
+  this.isDualStack = false
+  /**
    * the version ID parsed from the versionId query parameter (or null if not specified)
    * @type {string | null}
    */
@@ -90,6 +94,8 @@ function AmazonS3URI (uri, parseQueryString) {
   if (!matches) {
     throw new Error(`Invalid S3 URI: hostname does not appear to be a valid S3 endpoint: ${uri}`)
   }
+
+  this.isDualStack = /\.dualstack\./.test(this.uri.host)
 
   const prefix = matches[1]
   // A VPCE path-style endpoint has the vpce-id as the host prefix with no bucket, e.g.

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -129,6 +129,7 @@ const testCases = {
     bucket: 'bucket',
     key: 'key',
     versionId: null,
+    isDualStack: false,
     uri: { query: p ? {} : null }
   }),
   'https://bucket.s3.amazonaws.com/key with space': (p) => ({
@@ -201,6 +202,47 @@ const testCases = {
     region: 'us-east-1',
     bucket: 'bucket',
     key: 'key',
+    uri: { query: p ? {} : null }
+  }),
+  // dualstack endpoints
+  'https://s3.dualstack.us-east-1.amazonaws.com/bucket': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: null,
+    isDualStack: true,
+    uri: { query: p ? {} : null }
+  }),
+  'https://s3.dualstack.us-east-1.amazonaws.com/bucket/key': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    isDualStack: true,
+    uri: { query: p ? {} : null }
+  }),
+  'https://bucket.s3.dualstack.us-east-1.amazonaws.com': (p) => ({
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: null,
+    isDualStack: true,
+    uri: { query: p ? {} : null }
+  }),
+  'https://bucket.s3.dualstack.us-east-1.amazonaws.com/key': (p) => ({
+    isPathStyle: false,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    isDualStack: true,
+    uri: { query: p ? {} : null }
+  }),
+  'https://s3.dualstack.eu-west-1.amazonaws.com/bucket/key': (p) => ({
+    isPathStyle: true,
+    region: 'eu-west-1',
+    bucket: 'bucket',
+    key: 'key',
+    isDualStack: true,
     uri: { query: p ? {} : null }
   }),
   // versionId support


### PR DESCRIPTION
## Summary

- Extends `ENDPOINT_PATTERN` with `(?:dualstack\.)?` to correctly extract the region from dualstack hostnames (`s3.dualstack.<region>.amazonaws.com`) instead of capturing `dualstack` as the region
- Adds `isDualStack: boolean` property to parsed instances (`true` when the hostname contains `.dualstack.`)
- Updates README with full property table, supported URI format list, and `parseQueryString` example

## Test plan

- [x] Path-style dualstack with and without key (`s3.dualstack.us-east-1.amazonaws.com`)
- [x] Virtual-hosted dualstack with and without key (`bucket.s3.dualstack.us-east-1.amazonaws.com`)
- [x] Non-default region (`s3.dualstack.eu-west-1.amazonaws.com`) to confirm region extraction
- [x] Negative assertion (`isDualStack: false`) on a standard non-dualstack URL
- [x] All existing tests still pass, 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)