### PR TITLE
chore: remove stale URI encoding TODO

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -6,8 +6,6 @@ const url = require('url')
 const ENDPOINT_PATTERN = /^(.+\.)?s3[.-](?:dualstack\.)?([a-z0-9-]+)\./
 const DEFAULT_REGION = 'us-east-1'
 
-// TODO: encode uri before testing
-
 /**
  * A URI wrapper that can parse out information about an S3 URI
  *


### PR DESCRIPTION
## Summary

- Removes the `// TODO: encode uri before testing` comment that has been in the source since the initial implementation

## Why won't-fix

The Java reference implementation's `preprocessUrlStr` encodes the entire URI string before parsing, which lets characters like `#` or `?` in keys survive as literals. Replicating that in Node.js would encode `?` to `%3F`, breaking all query string support (`?versionId=…`, `?foo=bar`, etc.) — those params would become part of the key instead of being parsed separately.

The practical cases the TODO targeted (raw spaces in keys) are already handled by `url.parse` accepting raw spaces and `decodeURIComponent` decoding percent-encoded ones.

## Test plan

- [ ] `npm test` passes (no behavior change — comment-only removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)