### PR TITLE
fix: add explicit TypeError guard for non-string uri input

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -26,6 +26,9 @@ function AmazonS3URI (uri, parseQueryString) {
   if (new.target === undefined) {
     return new AmazonS3URI(uri, parseQueryString)
   }
+  if (typeof uri !== 'string') {
+    throw new TypeError(`uri must be a string, got ${typeof uri}`)
+  }
   /**
    * URL object from `url.parse`
    * @type { import('url').Url }


### PR DESCRIPTION
## Summary

- Adds an explicit `typeof uri !== 'string'` check at the top of the constructor, throwing a descriptive `TypeError` for non-string input

## Why

The existing tests assert `TypeError` for `AmazonS3URI()`, `AmazonS3URI(2)`, and `AmazonS3URI({})`. This contract was upheld implicitly — `url.parse` happens to throw `TypeError` internally for non-string arguments. Once `url.parse` is replaced with the `URL` constructor (planned for the next major version), that implicit behaviour could silently change. An explicit guard makes the contract durable regardless of the underlying URL parsing API.

## Test plan

- [ ] `npm test` passes (all 7 tests, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)