### PR TITLE
refactor: remove redundant isPathStyle assignment and avoid URLSearchParams when query is pre-parsed

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -65,7 +65,7 @@ function AmazonS3URI (uri, parseQueryString) {
    * @type {string | null}
    */
   this.versionId = parseQueryString
-    ? (this.uri.query.versionId || null)
+    ? (this.uri.query.versionId ?? null)
     : (this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null)
 
   if (this.uri.protocol === 's3:') {

--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -64,7 +64,9 @@ function AmazonS3URI (uri, parseQueryString) {
    * the version ID parsed from the versionId query parameter (or null if not specified)
    * @type {string | null}
    */
-  this.versionId = this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null
+  this.versionId = parseQueryString
+    ? (this.uri.query.versionId || null)
+    : (this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null)
 
   if (this.uri.protocol === 's3:') {
     this.bucket = this.uri.host
@@ -127,8 +129,6 @@ function AmazonS3URI (uri, parseQueryString) {
     }
   } else {
     // Bucket name was found in the host; path is the key.
-    this.isPathStyle = false
-
     // Remove the trailing '.' from the prefix to get the bucket.
     // For VPCE virtual-hosted URLs (bucket.vpce-<id>-<suffix>.s3…) strip the vpce suffix.
     const rawPrefix = prefix.substring(0, prefix.length - 1)

--- a/test/amazon-s3-uri.test.js
+++ b/test/amazon-s3-uri.test.js
@@ -269,6 +269,14 @@ const testCases = {
     key: 'key',
     versionId: 'xyz',
     uri: { query: p ? { versionId: 'xyz' } : 'versionId=xyz' }
+  }),
+  'https://s3.amazonaws.com/bucket/key?versionId=': (p) => ({
+    isPathStyle: true,
+    region: 'us-east-1',
+    bucket: 'bucket',
+    key: 'key',
+    versionId: '',
+    uri: { query: p ? { versionId: '' } : 'versionId=' }
   })
 }
 


### PR DESCRIPTION
## Summary

Two independent cleanups bundled together:

1. **Remove redundant `this.isPathStyle = false`** in the virtual-hosted `else` branch (`lib/amazon-s3-uri.js`) — the property is already initialised to `false` at the top of the constructor, so the reassignment is dead code.

2. **Avoid `URLSearchParams` allocation when `parseQueryString=true`** — `url.parse(uri, true)` already returns `query` as a parsed object, so `versionId` can be read directly from `this.uri.query` instead of constructing a `new URLSearchParams(this.uri.search)`.

   Before:
   ```js
   this.versionId = this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null
   ```
   After:
   ```js
   this.versionId = parseQueryString
     ? (this.uri.query.versionId || null)
     : (this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null)
   ```

## Test plan

- [ ] `npm test` passes (all 7 tests, 100% coverage — no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)