### PR TITLE
fix: guard versionId query access for TypeScript 6 strict null checks

### DIFF
--- a/lib/amazon-s3-uri.js
+++ b/lib/amazon-s3-uri.js
@@ -64,8 +64,8 @@ function AmazonS3URI (uri, parseQueryString) {
    * the version ID parsed from the versionId query parameter (or null if not specified)
    * @type {string | null}
    */
-  this.versionId = parseQueryString
-    ? (this.uri.query.versionId ?? null)
+  this.versionId = parseQueryString && typeof this.uri.query === 'object' && this.uri.query !== null
+    ? (typeof this.uri.query.versionId === 'string' ? this.uri.query.versionId : null)
     : (this.uri.search ? new URLSearchParams(this.uri.search).get('versionId') : null)
 
   if (this.uri.protocol === 's3:') {


### PR DESCRIPTION
## Summary

- TypeScript 6 (`^6.0.3`) tightened null-check defaults, breaking `npm run generate-types` with two errors on the `versionId` assignment (line 68):
  - **TS2531** — `this.uri.query` is possibly `null`
  - **TS2339** — `versionId` is not a property of `string | ParsedUrlQuery` (the `string` branch has no such property)
- Fix narrows the type with `typeof this.uri.query === 'object' && this.uri.query !== null` before accessing `.versionId`, and uses `typeof .versionId === 'string'` to handle the `string | string[] | undefined` element type safely
- Empty-string `versionId` behaviour from #358 is preserved (`typeof '' === 'string'` is `true`)

## Test plan

- [x] `npm run generate-types` passes with no TS errors
- [x] `npm test` passes with 100% branch coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)